### PR TITLE
Create constants for Screen Size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.6.1-pork2
+    Use constants to replace hardcoded screen size and some UI location
+
 1.6.0-pork2
     Contributions:
         mrtnvgr:

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -154,19 +154,18 @@ AppWindow::~AppWindow() { MidiService::GetInstance()->Close(); }
 void AppWindow::DrawString(const char *string, GUIPoint &pos,
                            GUITextProperties &props, bool force) {
 
-    // we know we don't have mode than 40 chars
-
+    // we know we don't have mode than 40 chars (SCREEN_WIDTH)
     char buffer[41];
     int len = strlen(string);
     int offset = (pos._x < 0) ? -pos._x / 8 : 0;
     len -= offset;
-    int available = 40 - ((pos._x < 0) ? 0 : pos._x);
+    int available = SCREEN_WIDTH - ((pos._x < 0) ? 0 : pos._x);
     len = MIN(len, available);
     memcpy(buffer, string + offset, len);
     buffer[len] = 0;
 
-    NAssert((pos._x < 40) && (pos._y < 30));
-    int index = pos._x + 40 * pos._y;
+    NAssert((pos._x < SCREEN_WIDTH) && (pos._y < SCREEN_HEIGHT));
+    int index = pos._x + SCREEN_WIDTH * pos._y;
     memcpy(_charScreen + index, buffer, len);
     unsigned char prop = colorIndex_ + (props.invert_ ? PROP_INVERT : 0);
     memset(_charScreenProp + index, prop, len);
@@ -188,15 +187,15 @@ void AppWindow::ClearRect(GUIRect &r) {
     int w = r.Width();
     int h = r.Height();
 
-    unsigned char *st = _charScreen + x + (40 * y);
-    unsigned char *pr = _charScreenProp + x + (40 * y);
+    unsigned char *st = _charScreen + x + (SCREEN_WIDTH * y);
+    unsigned char *pr = _charScreenProp + x + (SCREEN_WIDTH * y);
     for (int i = 0; i < h; i++) {
         for (int j = 0; j < w; j++) {
             *st++ = ' ';
             *pr++ = 0;
         }
-        st += (40 - w);
-        pr += (40 - w);
+        st += (SCREEN_WIDTH - w);
+        pr += (SCREEN_WIDTH - w);
     }
 };
 
@@ -238,8 +237,8 @@ void AppWindow::Flush() {
     unsigned char *previous = _preScreen;
     unsigned char *currentProp = _charScreenProp;
     unsigned char *previousProp = _preScreenProp;
-    for (int y = 0; y < 30; y++) {
-        for (int x = 0; x < 40; x++) {
+    for (int y = 0; y < SCREEN_HEIGHT; y++) {
+        for (int x = 0; x < SCREEN_WIDTH; x++) {
 #ifndef _LGPT_NO_SCREEN_CACHE_
             if ((*current != *previous) || (*currentProp != *previousProp)) {
 #endif
@@ -635,7 +634,7 @@ void AppWindow::Print(char *line) {
     Clear();
     strcpy(_statusLine, line);
     // unwrapped for gcc
-    int position = 40;
+    int position = SCREEN_WIDTH;
     position -= strlen(_statusLine);
     position /= 2;
     GUIPoint pos(position, 12);
@@ -643,8 +642,8 @@ void AppWindow::Print(char *line) {
     GUITextProperties props;
     SetColor(CD_NORMAL);
     DrawString(_statusLine, pos, props);
-    pos._y = 28;
-    pos._x = (40 - strlen(VERSION_STRING)) / 2;
+    pos._y = POS_Y_BEFORE_LAST_LINE;
+    pos._x = (SCREEN_WIDTH - strlen(VERSION_STRING)) / 2;
     DrawString(VERSION_STRING, pos, props);
     Flush();
 };

--- a/sources/Application/Build.h
+++ b/sources/Application/Build.h
@@ -7,8 +7,8 @@
 /** Used for incremental changes and improvements of the major version */
 #define VERSION_MINOR "6"
 
-/** Used for patch level changes, of the minor version */
-#define VERSION_PATCH "0"
+/** Used for patch level changes of the minor version */
+#define VERSION_PATCH "1"
 
 /** Used for namming */
 #define VERSION_NAME "Pork1"

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -42,9 +42,8 @@ View::View(GUIWindow &w,ViewData *viewData):
 } ;
 
 GUIPoint View::GetAnchor() {
-	int width=40 ;
-	int height=30 ;
-	return GUIPoint((width-SONG_CHANNEL_COUNT*3)/2+2,(height-View::songRowCount_)/2) ;
+    return GUIPoint((SCREEN_WIDTH - SONG_CHANNEL_COUNT * 3) / 2 + 2,
+                    (SCREEN_HEIGHT - View::songRowCount_) / 2);
 }
 
 GUIPoint View::GetTitlePosition() {

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -16,6 +16,11 @@
 #include <SDL/SDL.h>
 #endif
 
+#define SCREEN_WIDTH 40
+#define SCREEN_HEIGHT 30
+#define POS_Y_LAST_LINE 29
+#define POS_Y_BEFORE_LAST_LINE 28
+
 enum GUIEventPadButtonMasks {
     EPBM_LEFT = 1,
     EPBM_DOWN = 2,

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -132,12 +132,12 @@ void GrooveView::DrawView() {
 
 // Draw title
 
-	char title[40] ;
+    char title[SCREEN_WIDTH];
 
-	SetColor(CD_NORMAL) ;
+    SetColor(CD_NORMAL);
 
-	sprintf(title,"Groove: %2.2x",viewData_->currentGroove_) ;
-	DrawString(pos._x,pos._y,title,props) ;
+    sprintf(title, "Groove: %2.2x", viewData_->currentGroove_);
+    DrawString(pos._x,pos._y,title,props);
 
 // Compute song grid location
 

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -30,72 +30,72 @@ ImportSampleDialog::~ImportSampleDialog() {
 
 void ImportSampleDialog::DrawView() {
 
-	SetWindow(LIST_WIDTH,LIST_SIZE+3) ;
+    SetWindow(LIST_WIDTH, LIST_SIZE + 3);
 
-	GUITextProperties props ;
+    GUITextProperties props;
 
-// Draw title
+    // Draw title
 
-//	char title[40] ;
+    //	char title[SCREEN_WIDTH] ;
 
-	SetColor(CD_NORMAL) ;
+    SetColor(CD_NORMAL);
 
-//	sprintf(title,"Sample Import from %s",currentPath_.GetName()) ;
-//	w_.DrawString(title,pos,props) ;
+    //	sprintf(title,"Sample Import from %s",currentPath_.GetName()) ;
+    //	w_.DrawString(title,pos,props) ;
 
-// Draw samples
+    // Draw samples
 
-	int x=1 ;
-	int y=1 ;
+    int x = 1;
+    int y = 1;
 
-	if (currentSample_<topIndex_) {
-		topIndex_=currentSample_ ;
-	} ;
-	if (currentSample_>=topIndex_+LIST_SIZE) {
-		topIndex_=currentSample_ ;
-	} ;
+    if (currentSample_ < topIndex_) {
+        topIndex_=currentSample_;
+    }
+    if (currentSample_ >= topIndex_+LIST_SIZE) {
+		topIndex_=currentSample_;
+	}
 
-	IteratorPtr<Path> it(sampleList_.GetIterator()) ;
-	int count=0 ;
-	char buffer[256] ;
-	for(it->Begin();!it->IsDone();it->Next()) {
-		if ((count>=topIndex_)&&(count<topIndex_+LIST_SIZE)) {
+    IteratorPtr<Path> it(sampleList_.GetIterator());
+    int count = 0;
+    char buffer[256];
+	for(it->Begin(); !it->IsDone(); it->Next()) {
+		if ((count >= topIndex_) && (count < topIndex_ + LIST_SIZE)) {
 			Path &current=it->CurrentItem() ;
 			const std::string p=current.GetName() ;
 
-			if (count==currentSample_) {
-				SetColor(CD_HILITE2) ;
-				props.invert_=true ;
-			} else {
-				SetColor(CD_NORMAL) ;
-				props.invert_=false ;
+            if (count == currentSample_) {
+                SetColor(CD_HILITE2);
+				props.invert_=true;
+            } else {
+                SetColor(CD_NORMAL);
+                props.invert_=false;
+            }
+            if (!current.IsDirectory()) {
+                strcpy(buffer, p.c_str());
+            } else {
+                buffer[0] = '[';
+                strcpy(buffer + 1,p.c_str());
+				strcat(buffer, "]");
 			}
-			if (!current.IsDirectory()) {
-				strcpy(buffer,p.c_str()) ;
-			} else {
-				buffer[0]='[' ;
-				strcpy(buffer+1,p.c_str()) ;
-				strcat(buffer,"]") ;
-			}
-			buffer[LIST_WIDTH-1]=0 ;
-			DrawString(x,y,buffer,props) ;
-			y+=1 ;
+            buffer[LIST_WIDTH - 1] = 0;
+            DrawString(x, y, buffer, props) ;
+			y+=1;
 		}
-		count++ ;
-	} ;
+        count++;
+    };
 
-	y=LIST_SIZE+2 ;
-	int offset=LIST_WIDTH/4 ;
+    y = LIST_SIZE + 2;
+    int offset = LIST_WIDTH/4;
 
-	SetColor(CD_NORMAL) ;
+    SetColor(CD_NORMAL);
 
-	for (int i=0;i<3;i++) {
-		const char *text=buttonText[i] ;
-		x=offset*(i+1)-strlen(text)/2 ;
-		props.invert_=(i==selected_)?true:false ;
-		DrawString(x,y,text,props) ;
-	}	
-} ;
+    for (int i = 0; i < 3; i++) {
+        const char *text = buttonText[i];
+		x = offset * (i + 1) - strlen(text) / 2;
+		props.invert_ = (i == selected_) ? true : false;
+		DrawString(x, y, text, props);
+    }
+}
 
 void ImportSampleDialog::warpToNextSample(int direction) {
 

--- a/sources/Application/Views/NullView.cpp
+++ b/sources/Application/Views/NullView.cpp
@@ -20,8 +20,8 @@ void NullView::DrawView() {
 	SetColor(CD_HILITE2) ;
 
     GUIPoint pos;
-    pos._y=28;
-	pos._x=(40-strlen(VERSION_STRING))/2 ;
+    pos._y = POS_Y_BEFORE_LAST_LINE;
+    pos._x=(SCREEN_WIDTH-strlen(VERSION_STRING))/2 ;
     DrawString(pos._x, pos._y, VERSION_STRING, props);
 } ;
 

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -250,7 +250,8 @@ void ProjectView::DrawView() {
 
     // Draw version
     SetColor(CD_SONGVIEW00);
-    DrawString(40 - strlen(VERSION_STRING), 29, VERSION_STRING, props) ;
+    DrawString(SCREEN_WIDTH - strlen(VERSION_STRING), POS_Y_LAST_LINE,
+               VERSION_STRING, props);
 
     FieldView::Redraw();
     drawMap();


### PR DESCRIPTION
# Description
Just create constants to clarify when the screen size (width and/or heigh) is used.
Closes #15 

# How Has This Been Tested?
Testes just opening the lgpt.

**Test Configuration**: x64
* Hardware: Intel PC - Ubuntu
* Test steps: Launch and navigate through the pages.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented particularly in hard-to-understand areas
- [x] I have updated CHANGELOG
- [ ] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [x] I have version bumped in `sources/Application/Build.h`
- [x] My changes generate no new warnings (build without your change then apply your change to check this). Commit all your changes and run the command `tools/compare-builds`.
