### PR TITLE
Update compare-builds script

### DIFF
--- a/tools/compare-builds
+++ b/tools/compare-builds
@@ -12,10 +12,12 @@ TOP_LEVEL_DIR=$(git rev-parse --show-toplevel)
 LOG_DIR="$TOP_LEVEL_DIR/.build_logs"
 mkdir -p "$LOG_DIR"
 
-# Get current branch name
+# Get current branch name and commit hash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-LOG_CURRENT="${LOG_DIR}/${CURRENT_BRANCH}-build.log"
-LOG_MASTER="${LOG_DIR}/master-build.log"
+CURRENT_HASH=$(git rev-parse --short HEAD)
+MASTER_HASH=$(git rev-parse --short HEAD)
+LOG_CURRENT="${LOG_DIR}/${CURRENT_HASH}-build.log"
+LOG_MASTER="${LOG_DIR}/${MASTER_HASH}-build.log"
 
 cd "$TOP_LEVEL_DIR/projects/"
 
@@ -30,9 +32,9 @@ else
 fi
 
 # Build current branch
-echo "Checking out $CURRENT_BRANCH..."
+echo "Checking out $CURRENT_BRANCH (${CURRENT_HASH})..."
 git checkout "$CURRENT_BRANCH"
-echo "Building $CURRENT_BRANCH..."
+echo "Building $CURRENT_BRANCH (${CURRENT_HASH})..."
 make PLATFORM=X64 > "$LOG_CURRENT" 2>&1
 
 # Compare logs
@@ -43,17 +45,17 @@ WARNINGS_CURRENT_COUNT=$(echo "$WARNINGS_CURRENT" | wc -l)
 WARNINGS_MASTER_COUNT=$(echo "$WARNINGS_MASTER" | wc -l)
 echo "Comparing warnings..."
 echo "---"
-echo "Total warnings in $CURRENT_BRANCH: $WARNINGS_CURRENT_COUNT"
-echo "Total warnings in master: $WARNINGS_MASTER_COUNT"
+echo "Total warnings in $CURRENT_BRANCH (${CURRENT_HASH}): $WARNINGS_CURRENT_COUNT"
+echo "Total warnings in master (${MASTER_HASH}): $WARNINGS_MASTER_COUNT"
 echo "---"
 
 IFS=$'\n'
 if [ $WARNINGS_CURRENT_COUNT -eq $WARNINGS_MASTER_COUNT ]; then
     echo "Build outputs have same amount of warnings."
 elif [ $WARNINGS_CURRENT_COUNT -le $WARNINGS_MASTER_COUNT ]; then
-    echo "The $CURRENT_BRANCH has fewer warnings than master."
+    echo "The $CURRENT_BRANCH (${CURRENT_HASH}) has fewer warnings than master (${MASTER_HASH})."
 else
-    echo "The $CURRENT_BRANCH has more warnings than master."
+    echo "The $CURRENT_BRANCH (${CURRENT_HASH}) has more warnings than master (${MASTER_HASH})."
     for warning in $WARNINGS_CURRENT; do
         echo $warning
     done


### PR DESCRIPTION
# Description
Tooling improvement.

Update the compare-builds script to use commit-hash instead of the branch names.

# How Has This Been Tested?
This does not affect the source code, but the tooling to help to detect the warnings.
It was tested by executing the script.

# Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented particularly in hard-to-understand areas
- [ ] I have updated CHANGELOG
- [ ] I have updated docs/wiki/What-is-LittlePiggyTracker.md reflecting my changes
- [ ] I have version bumped in `sources/Application/Model/Project.h`
- [x] My changes generate no new warnings (build without your change then apply your change to check this)
